### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on: push
 jobs:
   ci:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source


### PR DESCRIPTION
Potential fix for [https://github.com/kaipaynter/theamericas/security/code-scanning/3](https://github.com/kaipaynter/theamericas/security/code-scanning/3)

To fix the problem, insert a `permissions:` block to explicitly restrict the GitHub Actions job's access to only what is required, thereby preventing unnecessary write privileges. As none of the listed steps (checkout, setup node, install, build) require `write` access to repository contents or pull requests, the minimum required permission is `contents: read`. This should be added either at the workflow root level (affecting all jobs) or under the specific job (`ci`) if more granularity is required—in this case, adding it at the job-level just above `runs-on:` ensures specificity. Only a single YAML block needs to be inserted, with no other code or dependencies changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
