### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ on:
     types: [completed]
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     # Only go ahead with the job if CI completed successfully (i.e. tests passed).
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
Potential fix for [https://github.com/kaipaynter/theamericas/security/code-scanning/2](https://github.com/kaipaynter/theamericas/security/code-scanning/2)

The best way to fix this issue is to set the `permissions` key explicitly in the workflow (`.github/workflows/cd.yml`) to provide the least privilege required for the job to operate: generally, `contents: write` is needed for deploying to GitHub Pages using `peaceiris/actions-gh-pages`, while the other steps (checkout, install, build) only require read access. The `permissions` key can be placed either at the top level (applying to all jobs), or at the job level (applying just to the `deploy` job). To minimally address the issue detected by CodeQL and restrict unnecessary access, add a `permissions` block for the `deploy` job with only `contents: write`. No external imports or extra packages are required for this change.

Edit `.github/workflows/cd.yml`:
- Add a `permissions` block to the `deploy` job, setting `contents: write`.
- Insert the block above the `runs-on: ubuntu-latest` line (line 11), as per GitHub Actions syntax.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
